### PR TITLE
fix(testing): resolve issue with timeouts

### DIFF
--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -137,7 +137,7 @@ export const config: Options.Testrunner = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        timeout: 10000
+        timeout: 20000
     },
 
     //


### PR DESCRIPTION
It seems like the Mocha timeout was the same as the `waitforTimeout` which will cause the test to fail because the test will likely reach the Mocha timeout which is the time WebdriverIO waits for the test to resolve.

If you wait for 3 elements to be displayed within 10 seconds, the test will only pass 30% of the time because every door needs to close within 3.3s to not hit the overall test timeout of 10s.

I will raise an issue in WebdriverIO to provide more information when the framework timeout is being hit since atm it only throws:
```
[0-0] Error in "open all three doors (expect)"
Error: Timeout
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7)
```

Which doesn't say anything about the timeout at all. We will have a fix within the next version ;-) 